### PR TITLE
Test if a devDependency causes a dependabot alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"jest-environment-jsdom-sixteen": "1.0.3",
 		"jest-image-snapshot": "4.0.2",
 		"jest-silent-reporter": "0.2.1",
+		"lodash": "4.17.19",
 		"memize": "1.1.0",
 		"npm-run-all": "4.1.5",
 		"pptr-testing-library": "0.6.1",


### PR DESCRIPTION
* Add an insecure lodash version to devDependencies to see if it causes a dependabot alert