### PR TITLE
Set dependabot.yml to ignore development dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    allow:
-      - dependency-type: "production"
+    ignore:
+      - dependency-type: "development"


### PR DESCRIPTION
* Set `dependabot.yml` to ignore development dependencies